### PR TITLE
Set `FollowsColorScheme=true`

### DIFF
--- a/Sweet-Blue-Filled/index.theme
+++ b/Sweet-Blue-Filled/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Blue-Filled
 Comment=Blue folders for Sweet theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Blue/index.theme
+++ b/Sweet-Blue/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Blue
 Comment=Blue folders for Sweet theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Mars/index.theme
+++ b/Sweet-Mars/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Mars
 Comment=Folders for Sweet-Mars gtk theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Purple-Filled/index.theme
+++ b/Sweet-Purple-Filled/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Purple-Filled
 Comment=Purple folders for Sweet theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Purple/index.theme
+++ b/Sweet-Purple/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Purple
 Comment=Purple folders for sweet theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Rainbow/index.theme
+++ b/Sweet-Rainbow/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Rainbow
 Comment=COlorful folders for Sweet theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Red-Filled/index.theme
+++ b/Sweet-Red-Filled/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Red-Filled
 Comment=Red folders for Sweet theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Red/index.theme
+++ b/Sweet-Red/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Red
 Comment=Red folders for Sweet theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Teal-Filled/index.theme
+++ b/Sweet-Teal-Filled/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Teal-Filled
 Comment=Teal folders for Sweet theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Teal/index.theme
+++ b/Sweet-Teal/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Teal
 Comment=Teal folders for Sweet theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Yellow-Filled/index.theme
+++ b/Sweet-Yellow-Filled/index.theme
@@ -3,6 +3,8 @@ Name=Sweer-Yellow-Flled
 Comment=Yellow folders for Sweer theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places

--- a/Sweet-Yellow/index.theme
+++ b/Sweet-Yellow/index.theme
@@ -3,6 +3,8 @@ Name=Sweet-Yellow
 Comment=Yellow folders for Sweet theme.
 Inherits=candy-icons,breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=Places


### PR DESCRIPTION
Add `FollowsColorScheme=true` to fix Breeze inherit icon colors

I'm having some troubles with breeze icon colors when using candy-icons and sweet-folders, with dark icon colors over dark color scheme.

This PR adds `FollowsColorScheme=true` to fix Breeze inherit icon colors

### **candy-icons** without `FollowsColorScheme`

![Imgur](https://i.imgur.com/YNGNpA5.png)

### **Sweet-Rainbow** with `FollowColorScheme`

![Imgur](https://i.imgur.com/2rVwWzK.png)